### PR TITLE
Fix NullPointerException in ExecutorTest

### DIFF
--- a/src/test/java/jp/co/chooyan/commander/ExecutorTest.java
+++ b/src/test/java/jp/co/chooyan/commander/ExecutorTest.java
@@ -9,6 +9,6 @@ import org.junit.Test;
 public class ExecutorTest {
     @Test
     public void testMain() {
-        Executor.main(new String[]{"/usr/local/workdir/java/commander/src/test/resources"});
+        Executor.main(new String[]{"./src/test/resources"});
     }
 }


### PR DESCRIPTION
NullPointerException in ExecutorTest#testMain because of specifying `/usr/local/workdir/java/commander/src/test/resources` for config.yml path.
